### PR TITLE
Enable multiple broker accounts for a single user

### DIFF
--- a/functions/common.js
+++ b/functions/common.js
@@ -1,11 +1,3 @@
-/**
- * Calculates the total profit for each date based on the given positions.
- * @param {Object[]} positions - An array of position objects.
- * @param {string} positions[].time - The timestamp for the position.
- * @param {number} positions[].profit - The profit for the position.
- * @param {number} positions[].dataCount - The number of positions for the date.
- * @returns {Object[]} An array of objects with date and total profit.
- */
 exports.getTotalProfitByDate = function (positions) {
   const timestamp = {}
   let baseAmount = 0
@@ -39,42 +31,31 @@ exports.getTotalProfitByDate = function (positions) {
   }
 }
 
-/**
-* Validates the authorization token and returns the user's UID.
-* Throws an error if the token is not provided or invalid.
-* @param {string} idToken - The ID token from the authorization header.
-* @param {Object} admin - Firebase admin SDK reference.
-* @returns {string} The UID of the authenticated user.
-* @throws {Error} Throws an error if the token is missing or invalid.
-*/
 exports.validateAuthorization = async function (idToken, admin) {
   if (!idToken) {
-    throw new Error({ status: 401, message: 'Authorization header not provided.' })
+    throw new Error('Authorization header not provided.')
   }
   const decodedToken = await admin.auth().verifyIdToken(idToken)
   if (!decodedToken) {
-    throw new Error({ status: 404, message: 'User data not found.' })
+    throw new Error('User data not found.')
   }
   return decodedToken.uid
 }
 
-/**
-* Retrieves platform data for the specified user.
-* @param {string} uid - The UID of the user.
-* @param {Object} firestore - Firestore instance.
-* @returns {Object} Platform data for the user.
-* @throws {Error} Throws an error if platform data is not found.
-*/
-exports.getPlatformData = async function (uid, firestore) {
-  const brokersRef = firestore.collection(`platforms/${uid}/brokers`)
-  const querySnapshot = await brokersRef.get()
-  const filteredBrokers = querySnapshot.docs.map(doc => doc.data())
-  if (!filteredBrokers.length) {
-    throw new Error({ status: 404, message: 'Platform data not found.' })
+exports.getPlatformData = async function (uid, firestore, platformId) {
+  const brokerRef = firestore.doc(`platforms/${uid}/brokers/${platformId}`)
+
+  const brokerSnapshot = await brokerRef.get()
+
+  if (!brokerSnapshot.exists) {
+    throw new Error('Platform data not found.')
   }
-  const userPlatformData = filteredBrokers[0]
+
+  const userPlatformData = brokerSnapshot.data()
+
   if (!userPlatformData.token || !userPlatformData.accountId) {
-    throw new Error({ status: 404, message: 'Missing params from your platform data.' })
+    throw new Error('Missing params from your platform data.')
   }
+
   return userPlatformData
 }

--- a/functions/getTrades.js
+++ b/functions/getTrades.js
@@ -11,22 +11,22 @@ exports.handler = async function (request, response, logger, admin, firestore, g
   try {
     logger.info('Hello logs!', { structuredData: true })
 
-    const platform = request.query.platform
-    if (!platform) {
+    const platformId = request.query.platformId
+    if (!platformId) {
       response.status(401).json({
-        message: 'Platform is required.'
+        message: 'Platform id is required.'
       })
       return
     }
 
     const uid = await validateAuthorization(request.headers.authorization, admin)
-    const userPlatformData = await getPlatformData(uid, firestore)
+    const userPlatformData = await getPlatformData(uid, firestore, platformId)
 
     let result = null
-    const { token, accountId } = userPlatformData
-    switch (platform) {
+    const { token, accountId, broker } = userPlatformData
+    switch (broker) {
       case MT4:
-        result = await fetchData(token, accountId, uid, getGlobalConnection)
+        result = await fetchData(token, accountId, uid, getGlobalConnection, platformId)
         response.status(200).json(result)
         break
       default:
@@ -45,9 +45,9 @@ exports.handler = async function (request, response, logger, admin, firestore, g
   }
 }
 
-async function fetchData (token, accountId, uid, getGlobalConnection) {
+async function fetchData (token, accountId, uid, getGlobalConnection, platformId) {
   try {
-    const connection = await getGlobalConnection(token, accountId, uid)
+    const connection = await getGlobalConnection(token, accountId, uid, platformId)
 
     const accountInformation = await connection.getAccountInformation()
     console.log('accountInformation', accountInformation)

--- a/functions/index.js
+++ b/functions/index.js
@@ -13,9 +13,10 @@ const corsHandler = cors({ origin: true })
 
 const globalConnection = {} // Declare the global variable to store the connection
 
-async function getGlobalConnection (token, accountId, uid) {
-  if (globalConnection[uid]) {
-    return globalConnection[uid] // If a connection already exists, return it
+async function getGlobalConnection (token, accountId, uid, platformId) {
+  const id = `${uid}-${platformId}`
+  if (globalConnection[id]) {
+    return globalConnection[id] // If a connection already exists, return it
   }
 
   const MetaApi = require('metaapi.cloud-sdk').default
@@ -23,12 +24,12 @@ async function getGlobalConnection (token, accountId, uid) {
   const account = await metaApi.metatraderAccountApi.getAccount(accountId)
 
   await account.waitConnected()
-  globalConnection[uid] = account.getRPCConnection()
+  globalConnection[id] = account.getRPCConnection()
 
-  await globalConnection[uid].connect()
-  await globalConnection[uid].waitSynchronized()
+  await globalConnection[id].connect()
+  await globalConnection[id].waitSynchronized()
 
-  return globalConnection[uid]
+  return globalConnection[id]
 }
 
 exports.getTrades = functions.https.onRequest((req, res) => {

--- a/src/components/Portfolio/matrix/growthChart.vue
+++ b/src/components/Portfolio/matrix/growthChart.vue
@@ -23,13 +23,11 @@ export default {
       return this.growthTrades.map(item => item.date)
     },
     growthPercentageData () {
-      let cumulativeGrowth = 0
       return this.growthTrades.map((item, index) => {
         if (index === 0 || item.growth === this.growthTrades[index - 1].growth) {
           return 0
         } else {
-          cumulativeGrowth += parseFloat(item.growth)
-          return cumulativeGrowth
+          return parseFloat(item.growth)
         }
       })
     }

--- a/src/firebase/firebase-functions.js
+++ b/src/firebase/firebase-functions.js
@@ -3,11 +3,13 @@ import { LocalStorage } from 'quasar'
 
 const fetchData = async (endpoint) => {
   try {
-    const platform = 'MetaTrader4' // TODO: add more platforms
+    // const platform = 'MetaTrader4' // TODO: add more platforms
+    const savedBrokerId = LocalStorage.getItem('selectedBrokerId')
+
     const user = LocalStorage.getItem('user')
     const authToken = await auth.currentUser?.getIdToken() ?? user?.stsTokenManager?.accessToken
 
-    const response = await fetch(`${process.env.BASE_URL}/${endpoint}?platform=${platform}`, {
+    const response = await fetch(`${process.env.BASE_URL}/${endpoint}?platformId=${savedBrokerId}`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
- Only 1 active broker account can be selected
- fixed cumulative making negatives to not show on graph
- added platform id on query to get account-specific details
- refresh page on platform id select for now to trigger all query
- save active platform id on localstorage
- bug: no active platform id on first login, no set id on storage yet